### PR TITLE
Add speech and damage hooks for features

### DIFF
--- a/Projects/UOContent/Custom/Features/MemoryFeature.cs
+++ b/Projects/UOContent/Custom/Features/MemoryFeature.cs
@@ -74,7 +74,7 @@ namespace Server.Custom.Features
 
         public override void OnSpeech(SpeechEventArgs e)
         {
-            // Pode armazenar interações relevantes
+            AddMemory($"{e.Mobile.Name}: \"{e.Speech}\"");
         }
 
         public override void OnThink() { }

--- a/Projects/UOContent/Custom/Mobiles/CustomCreature.cs
+++ b/Projects/UOContent/Custom/Mobiles/CustomCreature.cs
@@ -21,6 +21,9 @@ namespace Server.Custom.Mobiles
     {
         public CreatureManager CreatureManager { get; private set; }
 
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int EnrageDamageThreshold { get; set; } = 50;
+
         // Construtor base
         private void InitCreatureManager()
         {
@@ -87,6 +90,25 @@ namespace Server.Custom.Mobiles
             if (Combatant != null)
                 CreatureManager?.OnCombat(Combatant);
             base.OnCombatantChange();
+        }
+
+        public override void OnSpeech(SpeechEventArgs e)
+        {
+            CreatureManager?.OnSpeech(e);
+            base.OnSpeech(e);
+        }
+
+        public override void OnDamage(int amount, Mobile from, bool willKill)
+        {
+            if (amount > EnrageDamageThreshold)
+            {
+                if (CreatureManager?.Features.TryGetValue("rage", out var feature) == true && feature is RageFeature rf)
+                {
+                    rf.TriggerEnrage();
+                }
+            }
+
+            base.OnDamage(amount, from, willKill);
         }
 
         public override void Serialize(IGenericWriter writer)


### PR DESCRIPTION
## Summary
- enable features to process speech and high damage for custom creatures
- log player speech in `MemoryFeature`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463d4dd1fc832fa604b08d8740a235