### PR TITLE
Fix CompanionFeature serialization bug

### DIFF
--- a/Projects/UOContent/Custom/Features/CompanionFeatures/CompanionFeature.cs
+++ b/Projects/UOContent/Custom/Features/CompanionFeatures/CompanionFeature.cs
@@ -163,7 +163,6 @@ namespace Server.Custom.Companions
 
         public override void Serialize(IGenericWriter writer)
         {
-            writer.Write(0); // version
             writer.Write(1); // version
             writer.Write(CompanionName);
             writer.Write(Personality);


### PR DESCRIPTION
## Summary
- fix double version write in CompanionFeature serialization

## Testing
- `./publish.sh Release` *(fails: dotnet not found)*
- `dotnet test --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846624b50b4832fa43c1db6e8b5614a