### PR TITLE
Fix loot generation call

### DIFF
--- a/Projects/UOContent/Custom/Mobiles/CustomCreature.cs
+++ b/Projects/UOContent/Custom/Mobiles/CustomCreature.cs
@@ -148,34 +148,8 @@ namespace Server.Custom.Mobiles
                 m_KillersDropMultiplier = GetKillerDropMultiplier();
             }
 
-            base.GenerateLoot();
+            base.GenerateLoot(spawning);
 
-            if (IsParagon)
-            {
-                if (Fame < 1250)
-                {
-                    AddLoot(LootPack.Meager);
-                }
-                else if (Fame < 2500)
-                {
-                    AddLoot(LootPack.Average);
-                }
-                else if (Fame < 5000)
-                {
-                    AddLoot(LootPack.Rich);
-                }
-                else if (Fame < 10000)
-                {
-                    AddLoot(LootPack.FilthyRich);
-                }
-                else
-                {
-                    AddLoot(LootPack.UltraRich);
-                }
-            }
-
-            m_Spawning = false;
-            m_KillersLuck = 0;
             m_KillersDropMultiplier = 1.0;
         }
 


### PR DESCRIPTION
## Summary
- ensure CustomCreature calls base.GenerateLoot(spawning) so derived loot methods run
- remove duplicate Paragon loot section
- reset drop multiplier after generating loot

## Testing
- `./publish.sh Release` *(fails: dotnet not found)*
- `dotnet test --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467d9569e8832fb58aa64f78f0a82f