### PR TITLE
Fix null references in NPC memory usage

### DIFF
--- a/Projects/UOContent/Custom/Features/NpcIntelligenceFeature.cs
+++ b/Projects/UOContent/Custom/Features/NpcIntelligenceFeature.cs
@@ -86,7 +86,8 @@ namespace Server.Custom.Features
 
                                 try
                                 {
-                                    string resultado = memory.SearchMemory(termo);
+                                    string resultado = memory?.SearchMemory(termo) ??
+                                        "Nao consigo me lembrar disso.";
                                     string emocao = DetectarEmocao(resultado);
                                     await FalarComEmocao(resultado, emocao, playerLang);
                                 }
@@ -128,7 +129,7 @@ namespace Server.Custom.Features
                                 mood = "neutro",
                                 item_amount = creature.Backpack.GetAmount(typeof(Gold)).ToString() ?? "0",
                                 item_name = "",
-                                memory = memory.GetRecentMemories() ?? new List<string>(),
+                                memory = memory?.GetRecentMemories() ?? new List<string>(),
                                 nearby_npcs = nearbyNpcsList ?? new List<AIService.NearbyNPC>(),
                                 player_input = e.Speech.ToLower(),
                                 player_name = e.Mobile.Name
@@ -150,9 +151,9 @@ namespace Server.Custom.Features
                                     }
                                 }
 
-                                memory.AddMemory($"Interagiu com {e.Mobile.Name}, que disse: \"{e.Speech}\"");
+                                memory?.AddMemory($"Interagiu com {e.Mobile.Name}, que disse: \"{e.Speech}\"");
                                 if (!string.IsNullOrWhiteSpace(decision.say))
-                                    memory.AddMemory($"Respondeu: \"{decision.say}\"");
+                                    memory?.AddMemory($"Respondeu: \"{decision.say}\"");
 
                                 if (!string.IsNullOrWhiteSpace(decision.say))
                                 {


### PR DESCRIPTION
## Summary
- prevent `NullReferenceException` in `NpcIntelligenceFeature` when memory feature is absent

## Testing
- `./publish.sh Release` *(fails: dotnet not found)*
- `dotnet test --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a58cdf18832fa25c8b051f3e7830