### PR TITLE
Fix null check for NPC backpack

### DIFF
--- a/Projects/UOContent/Custom/Features/NpcIntelligenceFeature.cs
+++ b/Projects/UOContent/Custom/Features/NpcIntelligenceFeature.cs
@@ -137,7 +137,7 @@ namespace Server.Custom.Features
                                 background = GetBackground() ?? "",
                                 location = creature.Location.ToString() ?? "",
                                 mood = "neutro",
-                                item_amount = creature.Backpack.GetAmount(typeof(Gold)).ToString() ?? "0",
+                                item_amount = creature.Backpack?.GetAmount(typeof(Gold)).ToString() ?? "0",
                                 item_name = "",
                                 memory = memory?.GetRecentMemories() ?? new List<string>(),
                                 nearby_npcs = nearbyNpcsList ?? new List<AIService.NearbyNPC>(),


### PR DESCRIPTION
## Summary
- handle missing backpack when building NPC state for AI

## Testing
- `./publish.sh Release` *(fails: dotnet not found)*
- `dotnet test --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846aa570f0c832fb87bffd31ec54fa4