### PR TITLE
Implement persistent flee with CustomBaseAI

### DIFF
--- a/Projects/UOContent/Custom/AI/AIService.cs
+++ b/Projects/UOContent/Custom/AI/AIService.cs
@@ -214,3 +214,43 @@ namespace Server.Services.AI
         }
     }
 }
+        public static async Task<NpcDecision> DecideNpcActionNewAsync(FullNPCState state)
+        {
+            var json = JsonSerializer.Serialize(state);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            try
+            {
+                var response = await httpClient.PostAsync("http://localhost:10000/npc/decide/new", content);
+                response.EnsureSuccessStatusCode();
+
+                var responseString = await response.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<NpcDecision>(responseString);
+            }
+            catch (TaskCanceledException)
+            {
+                return new NpcDecision
+                {
+                    type = GetNpcActionString(NpcAction.NENHUMA),
+                    target = "",
+                    say = "Estou pensando demais no momento...",
+                    item_amount = "0",
+                    item_name = "",
+                    details = "timeout"
+                };
+            }
+            catch (Exception ex)
+            {
+                return new NpcDecision
+                {
+                    type = GetNpcActionString(NpcAction.NENHUMA),
+                    target = "",
+                    say = ex.Message,
+                    item_amount = "0",
+                    details = ex.Message
+                };
+            }
+        }
+    }
+}
+

--- a/Projects/UOContent/Custom/AI/CustomBaseAI.cs
+++ b/Projects/UOContent/Custom/AI/CustomBaseAI.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using Server.Mobiles;
+using Server.Services.AI;
+
+namespace Server.Mobiles
+{
+    public class CustomBaseAI : BaseAI
+    {
+        private bool _forceFlee;
+
+        public CustomBaseAI(BaseCreature m) : base(m)
+        {
+        }
+
+        public override bool DoActionFlee()
+        {
+            var from = m_Mobile.FocusMob ?? m_Mobile.Combatant;
+            if (from == null || from.Deleted || from.Map != m_Mobile.Map)
+            {
+                Action = ActionType.Flee;
+                return true;
+            }
+
+            WalkMobileRange(from, 1, true, m_Mobile.RangePerception * 2, m_Mobile.RangePerception * 3);
+            Action = ActionType.Flee;
+            _ = SendFleeFeedback();
+            return true;
+        }
+
+        private async Task SendFleeFeedback()
+        {
+            var state = new AIService.FullNPCState
+            {
+                npc_id = m_Mobile.Serial.ToString(),
+                name = m_Mobile.Name,
+                role = m_Mobile.Title ?? "npc",
+                background = string.Empty,
+                location = m_Mobile.Location.ToString(),
+                mood = "neutro",
+                item_amount = m_Mobile.Backpack?.GetAmount(typeof(Gold)).ToString() ?? "0",
+                item_name = string.Empty,
+                memory = new(),
+                nearby_npcs = new(),
+                player_input = string.Empty,
+                player_name = string.Empty
+            };
+
+            var decision = await AIService.DecideNpcActionNewAsync(state);
+            if (decision != null && decision.type != AIService.GetNpcActionString(AIService.NpcAction.FUGIR))
+            {
+                _forceFlee = false;
+                Action = ActionType.Guard;
+            }
+        }
+    }
+}
+

--- a/Projects/UOContent/Custom/Features/NpcIntelligenceFeature.cs
+++ b/Projects/UOContent/Custom/Features/NpcIntelligenceFeature.cs
@@ -253,12 +253,9 @@ namespace Server.Custom.Features
 
         protected void FugaPorSpeech(Mobile from, AIService.NpcDecision decision, string playerLang)
         {
-            Mobile target = null;
-            if (Owner.Combatant != null)
+            if (Owner.AIObject != null)
             {
-                target = Owner.Combatant;
-                Owner.AIObject.DoActionFlee();
-
+                Owner.AIObject.Action = ActionType.Flee;
             }
         }
 

--- a/Projects/UOContent/Mobiles/AI/AnimalAI.cs
+++ b/Projects/UOContent/Mobiles/AI/AnimalAI.cs
@@ -9,7 +9,7 @@
 
 namespace Server.Mobiles;
 
-public class AnimalAI : BaseAI
+public class AnimalAI : CustomBaseAI
 {
     public AnimalAI(BaseCreature m) : base(m)
     {

--- a/Projects/UOContent/Mobiles/AI/ArcherAI.cs
+++ b/Projects/UOContent/Mobiles/AI/ArcherAI.cs
@@ -3,7 +3,7 @@ using Server.Items;
 
 namespace Server.Mobiles;
 
-public class ArcherAI : BaseAI
+public class ArcherAI : CustomBaseAI
 {
     public ArcherAI(BaseCreature m) : base(m)
     {

--- a/Projects/UOContent/Mobiles/AI/BerserkAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BerserkAI.cs
@@ -1,6 +1,6 @@
 namespace Server.Mobiles;
 
-public class BerserkAI : BaseAI
+public class BerserkAI : CustomBaseAI
 {
     public BerserkAI(BaseCreature m) : base(m)
     {

--- a/Projects/UOContent/Mobiles/AI/HealerAI.cs
+++ b/Projects/UOContent/Mobiles/AI/HealerAI.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 
 namespace Server.Mobiles;
 
-public class HealerAI : BaseAI
+public class HealerAI : CustomBaseAI
 {
     private static readonly NeedDelegate m_Cure = NeedCure;
     private static readonly NeedDelegate m_GHeal = NeedGHeal;

--- a/Projects/UOContent/Mobiles/AI/MageAI.cs
+++ b/Projects/UOContent/Mobiles/AI/MageAI.cs
@@ -13,7 +13,7 @@ using Server.Targeting;
 
 namespace Server.Mobiles;
 
-public class MageAI : BaseAI
+public class MageAI : CustomBaseAI
 {
     private const double HealChance = 0.10;     // 10% chance to heal at gm magery
     private const double TeleportChance = 0.05; // 5% chance to teleport at gm magery

--- a/Projects/UOContent/Mobiles/AI/MeleeAI.cs
+++ b/Projects/UOContent/Mobiles/AI/MeleeAI.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Mobiles;
 
-public class MeleeAI : BaseAI
+public class MeleeAI : CustomBaseAI
 {
     public MeleeAI(BaseCreature m) : base(m)
     {

--- a/Projects/UOContent/Mobiles/AI/PredatorAI.cs
+++ b/Projects/UOContent/Mobiles/AI/PredatorAI.cs
@@ -1,6 +1,6 @@
 namespace Server.Mobiles;
 
-public class PredatorAI : BaseAI
+public class PredatorAI : CustomBaseAI
 {
     public PredatorAI(BaseCreature m) : base(m)
     {

--- a/Projects/UOContent/Mobiles/AI/ThiefAI.cs
+++ b/Projects/UOContent/Mobiles/AI/ThiefAI.cs
@@ -3,7 +3,7 @@ using Server.Items;
 
 namespace Server.Mobiles;
 
-public class ThiefAI : BaseAI
+public class ThiefAI : CustomBaseAI
 {
     private Item m_toDisarm;
 

--- a/Projects/UOContent/Mobiles/AI/VendorAI.cs
+++ b/Projects/UOContent/Mobiles/AI/VendorAI.cs
@@ -2,7 +2,7 @@ using System.Runtime.CompilerServices;
 
 namespace Server.Mobiles;
 
-public class VendorAI : BaseAI
+public class VendorAI : CustomBaseAI
 {
     // Guards! A villan attacks me!
     // Guards! Help!


### PR DESCRIPTION
## Summary
- add `CustomBaseAI` that keeps NPCs in flee mode and sends feedback to the new API endpoint
- add helper `DecideNpcActionNewAsync` to AIService
- use `CustomBaseAI` for all existing AI classes
- trigger flee mode from NpcIntelligenceFeature

## Testing
- `./publish.sh Release` *(fails: dotnet not found)*
- `dotnet test --no-restore` *(fails: dotnet not found)*


------
https://chatgpt.com/codex/tasks/task_e_6846c94e2f6c832fa331da30a1093fb4